### PR TITLE
test: cover Floci AWS connection details auto-configuration

### DIFF
--- a/spring-boot-testcontainers-floci/src/test/java/io/floci/testcontainers/spring/FlociAutoConfigurationTest.java
+++ b/spring-boot-testcontainers-floci/src/test/java/io/floci/testcontainers/spring/FlociAutoConfigurationTest.java
@@ -10,6 +10,8 @@ import org.springframework.context.annotation.Configuration;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import software.amazon.awssdk.services.s3.S3Client;
+import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
+import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,6 +22,9 @@ class FlociAutoConfigurationTest {
     @Container
     @ServiceConnection
     static FlociContainer flociContainer = new FlociContainer();
+    
+    @Autowired
+    private AwsConnectionDetails awsConnectionDetails;
 
     @Autowired
     private S3Client s3Client;
@@ -31,6 +36,18 @@ class FlociAutoConfigurationTest {
 
         var buckets = s3Client.listBuckets().buckets();
         assertThat(buckets).anyMatch(b -> b.name().equals(bucketName));
+    }
+    
+    @Test
+    void shouldExposeFlociAwsConnectionDetails() {
+        assertThat(awsConnectionDetails.getEndpoint())
+                .isEqualTo(URI.create(flociContainer.getEndpoint()));
+        assertThat(awsConnectionDetails.getRegion())
+                .isEqualTo(flociContainer.getRegion());
+        assertThat(awsConnectionDetails.getAccessKey())
+                .isEqualTo(flociContainer.getAccessKey());
+        assertThat(awsConnectionDetails.getSecretKey())
+                .isEqualTo(flociContainer.getSecretKey());
     }
 
     @Configuration


### PR DESCRIPTION
## Summary

Add behavior-level test coverage for the Spring Boot `@ServiceConnection`
integration by asserting that `AwsConnectionDetails` exposes the values
provided by `FlociContainer`.

## Changes

- Verify configured endpoint matches the Floci container endpoint
- Verify region propagation
- Verify access key propagation
- Verify secret key propagation

## Why

The existing connection-details factory test only checks that the factory
can be instantiated. This adds coverage for the actual values exposed to
Spring Cloud AWS auto-configuration.

## Verification

- `mvn -pl spring-boot-testcontainers-floci -Dtest=FlociAutoConfigurationTest test`
- `mvn verify`