### PR TITLE
fix: wait for startup scripts to complete

### DIFF
--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/FlociContainer.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/FlociContainer.java
@@ -151,8 +151,10 @@ public class FlociContainer extends GenericContainer<FlociContainer> {
 
         // Configure observability and healthcheck
         withLogLevel(Level.WARN);
-        waitingFor(Wait.forHttp("/_floci/health")
+        waitingFor(Wait.forHttp("/_floci/init")
                 .forPort(PORT)
+                .forStatusCode(200)
+                .forResponsePredicate(response -> response.matches("(?s).*\"ready\"\\s*:\\s*true.*"))
                 .withStartupTimeout(Duration.ofSeconds(30)));
 
         // Configure ports and env vars

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/FlociContainerTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/FlociContainerTest.java
@@ -3,6 +3,7 @@ package io.floci.testcontainers;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.Level;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.images.builder.Transferable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -127,6 +128,23 @@ class FlociContainerTest {
             String network1 = container1.getDedicatedNetworkName();
             String network2 = container2.getDedicatedNetworkName();
             assertThat(network1).isNotEqualTo(network2);
+        }
+    }
+    
+    @Test
+    void shouldWaitForStartScriptsToComplete() throws Exception {
+        try (FlociContainer container = new FlociContainer()) {
+            container.withCopyToContainer(Transferable.of("""
+                    #!/bin/sh
+                    set -eu
+                    sleep 2
+                    touch /tmp/floci-start-script-completed
+                    """, 0777), "/etc/floci/init/start.d/01-slow-start.sh");
+
+            container.start();
+
+            assertThat(container.execInContainer("test", "-f", "/tmp/floci-start-script-completed")
+                    .getExitCode()).isZero();
         }
     }
 }


### PR DESCRIPTION
## Summary

Update `FlociContainer` to wait for Floci initialization readiness instead of only the health endpoint.

`/_floci/health` can return `200` while `start.d` scripts are still running. Waiting for `/_floci/init` with `"ready": true` ensures startup scripts have completed before `container.start()` returns.

## Related issue

Fixes #151

## Type of change

* [x] Bug fix (`fix:` commit)
* [ ] New feature (`feat:` commit)
* [ ] Breaking change (`feat!:` commit or `BREAKING CHANGE:` footer)
* [ ] Documentation or chore

## Checklist

* [ ] `mvn verify` passes locally (requires Docker)
* [x] New or changed behaviour is covered by tests
* [x] All commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)

## Verification

* `mvn -pl testcontainers-floci -Dtest=FlociContainerTest test`
* `mvn -pl testcontainers-floci -DskipTests package`

Note: full `mvn verify` had unrelated baseline failures locally in CloudFront, Config, and Neptune service tests before this change.