### PR TITLE
Stop Floci gracefully

### DIFF
--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/FlociContainer.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/FlociContainer.java
@@ -57,6 +57,7 @@ public class FlociContainer extends GenericContainer<FlociContainer> {
     public static final int PORT = 4566;
 
     private static final String DOCKER_SOCKET_PATH = "/var/run/docker.sock";
+    private static final int STOP_TIMEOUT_SECONDS = 30;
 
     private static final String DEFAULT_REGION = "us-east-1";
     private static final String DEFAULT_AVAILABILITY_ZONE = "us-east-1a";
@@ -253,8 +254,23 @@ public class FlociContainer extends GenericContainer<FlociContainer> {
     @Override
     public void stop() {
         preparePersistentStorageForCleanup();
+        stopGracefully();
         super.stop();
         deletePersistentStorage();
+    }
+
+    private void stopGracefully() {
+        if (!isRunning()) {
+            return;
+        }
+
+        try {
+            dockerClient.stopContainerCmd(getContainerId())
+                    .withTimeout(STOP_TIMEOUT_SECONDS)
+                    .exec();
+        } catch (RuntimeException e) {
+            logger.warn("Failed to stop Floci gracefully; forcing container removal", e);
+        }
     }
 
     /**

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/FlociContainerTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/FlociContainerTest.java
@@ -3,7 +3,9 @@ package io.floci.testcontainers;
 import io.floci.testcontainers.config.services.AbstractServiceConfig;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.event.Level;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.images.builder.Transferable;
 import org.testcontainers.utility.DockerImageName;
 
@@ -151,6 +153,23 @@ class FlociContainerTest {
             assertThat(container.execInContainer("test", "-f", "/tmp/floci-start-script-completed")
                     .getExitCode()).isZero();
         }
+    }
+
+    @Test
+    void shouldRunShutdownHooksWhenStopped(@TempDir Path temporaryDirectory) {
+        Path shutdownMarker = temporaryDirectory.resolve("completed");
+        try (FlociContainer container = new FlociContainer().disableAllServices()
+                .withFileSystemBind(temporaryDirectory.toString(), "/tmp/floci-shutdown", BindMode.READ_WRITE)) {
+            container.withCopyToContainer(Transferable.of("""
+                    #!/bin/sh
+                    set -eu
+                    touch /tmp/floci-shutdown/completed
+                    """, 0777), "/etc/floci/init/shutdown.d/01-mark-shutdown.sh");
+
+            container.start();
+        }
+
+        assertThat(shutdownMarker).exists();
     }
 
     @Test


### PR DESCRIPTION
## Why
- Stopping Floci through Testcontainers force-removes the main container before its shutdown hooks can run.
- Docker-backed services such as RDS rely on those hooks to remove their sibling containers.
- Leaked service containers accumulate and can interfere with later tests and development environments.

## Approach
- Request a normal Docker stop with a 30-second timeout, while retaining the existing force-removal path as a fallback.
- Cover shutdown-hook execution with a regression test.