### PR TITLE
fix(release): Skip snapshot-bump PRs in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,5 +11,6 @@
   ],
   "packages": {
     ".": {}
-  }
+  },
+  "skip-snapshot": true
 }


### PR DESCRIPTION
## Problem

The release-please PR for `main` (#330) is empty and titled `chore(main): release 2.14.1-SNAPSHOT` instead of proposing the expected `2.15.0` release with the accumulated `feat:`/`fix:` commits.

## Root cause

`release-type: maven` wraps every package in release-please's Java snapshot state machine. Before computing a real release, it calls `needsSnapshot()`, which decides whether a snapshot-bump PR was already merged since the last release by checking which PR each intervening commit is associated with.

That heuristic breaks down here: since the release-please bot branch (`release-please--branches--main`) is rebuilt from the target branch tip on every run, every commit since the last release ends up "associated" with the bot's own long-lived PR. Once that PR's title holds a real release version (not `-SNAPSHOT`), `needsSnapshot()` finds zero qualifying snapshot commits and permanently concludes a snapshot bump is needed — so every run just re-proposes the current `pom.xml` version as a no-op PR instead of computing the real bump.

I verified this by running release-please 17.6.0 (the version pinned by `release-please-action@45996ed1...` / v5.0.0) locally in dry-run mode against this repo, then confirmed the fix by dry-running against a throwaway branch with this same config change — it correctly produced `chore(...): release 2.15.0` with the full changelog.

## Fix

Add `skip-snapshot: true`, which bypasses that state machine entirely so release-please always computes the real release version directly from conventional commits. The interim "prepare next SNAPSHOT" PR that heuristic exists for is a leftover convention from the old `maven-release-plugin` flow this repo migrated away from — not something needed here.

Companion fix for `releases/1.x` (which has the identical config and is about to hit the same bug on its next run) will follow in a separate PR against that base branch.