### PR TITLE
fix(release): Skip snapshot-bump PRs in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,5 +11,6 @@
   ],
   "packages": {
     ".": {}
-  }
+  },
+  "skip-snapshot": true
 }


### PR DESCRIPTION
Companion to #338 for the `releases/1.x` branch.

`releases/1.x` currently shows a correct `chore(releases/1.x): release 1.14.0` PR (#329), but this is only luck of timing — a local dry-run against the current live state of this branch reproduces the same "needs a snapshot bump" trap described in #338, so the next run against this branch would regress #329 to an empty no-op SNAPSHOT PR the same way it happened on `main`.

See #338 for the full root-cause analysis.