### PR TITLE
fix(release): Allow manual dispatch to publish/scan an existing tag

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,15 @@ name: Release Please
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: >-
+          Existing release tag to (re)publish and security-scan (e.g. v2.15.0), bypassing the
+          release-please gate. Use this to recover a release whose tag/GitHub Release was created
+          out-of-band (so release-please never reported release_created=true) or to re-run a failed
+          publish/security-scan job. Leave empty for a normal dry run of just the release-please step.
+        required: false
 
 permissions:
   contents: read
@@ -31,14 +40,14 @@ jobs:
   # Step 2: Build the release tag and publish to Maven Central
   publish:
     needs: release-please
-    if: needs.release-please.outputs.release-created == 'true'
+    if: needs.release-please.outputs.release-created == 'true' || inputs.tag != ''
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.release-please.outputs.tag-name }}
+          ref: ${{ inputs.tag || needs.release-please.outputs.tag-name }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
@@ -62,7 +71,7 @@ jobs:
   # Step 3: Run security scanners against the release tag
   security-scan:
     needs: release-please
-    if: needs.release-please.outputs.release-created == 'true'
+    if: needs.release-please.outputs.release-created == 'true' || inputs.tag != ''
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -70,7 +79,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.release-please.outputs.tag-name }}
+          ref: ${{ inputs.tag || needs.release-please.outputs.tag-name }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4


### PR DESCRIPTION
Adds a workflow_dispatch trigger with an optional `tag` input so publish and security-scan can be re-run against an already-tagged release when release-please's own tagging step didn't fire (e.g. release_created never became true), without waiting for a new push to main.

This is the recovery path used for v2.15.0: release-please merged the 2.15.0 release PR but never tagged it, because that PR was still carrying a stale autorelease: snapshot label left over from before skip-snapshot was enabled, so the tagging step found no PR labeled autorelease: pending to release. The v2.15.0 tag/GitHub Release were created out-of-band; this dispatch path lets publish/security-scan catch up for that tag.

## Summary

<!-- Briefly describe what this PR does and why. -->

## Related issue

<!-- Link the issue this PR addresses, e.g. "Fixes #123" or "Closes #456". -->
<!-- If there is no issue, explain why the change is needed. -->

## Type of change

<!-- Check the one that applies. -->

- [ ] Bug fix (`fix:` commit)
- [ ] New feature (`feat:` commit)
- [ ] Breaking change (`feat!:` commit or `BREAKING CHANGE:` footer)
- [ ] Documentation or chore

## Checklist

- [ ] `mvn verify` passes locally (requires Docker)
- [ ] New or changed behaviour is covered by tests
- [ ] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
