### PR TITLE
fix: mount Docker socket only when a service needs it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,9 @@ When Floci adds a new service, the typical steps are:
 
 1. Create `testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/<Service>Config.java`
    following the pattern of existing config classes (extend `AbstractServiceConfig`, inner `Builder`, env var naming
-   `FLOCI_SERVICES_<SERVICE>_<PROPERTY>`).
+   `FLOCI_SERVICES_<SERVICE>_<PROPERTY>`). If the service creates sibling Docker containers (like RDS or Lambda),
+   override `requiresDockerSocket()` to return `true` while enabled (and, for services with a docker-less `mock`
+   mode, only while not mocked) — this drives whether `FlociContainer` mounts the host Docker socket.
 2. Wire the config into `FlociContainer`: add a field, a `get<Service>Config()` getter, a `with<Service>Config(...)`
    method, and register in `configureEnvVars()` (and `configureExposedPorts()` if the service exposes extra ports).
 3. Add a config unit test in `testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/`.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ class S3IntegrationTest {
 | `withDefaultAccountId(String)`        | Sets the default AWS account ID (default: `000000000000`)                                                      |
 | `withLogLevel(Level)`                 | Sets the Floci log level (`TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`)                                           |
 | `withDedicatedNetwork()`              | Creates a dedicated Docker network shared by Floci and its sibling containers (RDS, Lambda, ElastiCache, etc.) |
+| `withDockerSocket(boolean)`           | Overrides whether the host Docker socket is mounted, bypassing auto-detection (see below)                      |
 | `withTlsConfig(...)`                  | Configures TLS/HTTPS (self-signed by default; optionally provide cert/key paths)                               |
 | `withStorageConfig(...)`              | Configures persistent storage and volume behaviour                                                             |
 | `withSecurityConfig(...)`             | Configures CORS-related security settings                                                                      |
@@ -174,6 +175,25 @@ Example — disable a service and customize another:
 FlociContainer floci = new FlociContainer()
     .withSqsConfig(c -> c.defaultVisibilityTimeout(60).maxMessageSize(131072))
     .withDynamoDbConfig(c -> c.enabled(false));
+```
+
+#### Docker socket
+
+Some services (RDS, Lambda, ElastiCache, ECS, and others) spin up sibling Docker containers and need
+access to the host Docker socket. `FlociContainer` mounts the socket automatically, but only when at
+least one currently enabled service actually needs it — e.g. a container that only uses S3/SQS/DynamoDB
+never gets the socket mounted once the Docker-backed services are disabled (all services are enabled by default).
+
+Use `withDockerSocket(boolean)` to override this auto-detection entirely, regardless of which services
+are enabled:
+
+```java
+// Never mount the socket, e.g. on hosts where mounting it doesn't work
+// (such as rootless Podman with SELinux) and no Docker-backed service is needed
+FlociContainer floci = new FlociContainer().withDockerSocket(false);
+
+// Always mount the socket, even if no currently enabled service is detected as needing it
+FlociContainer floci = new FlociContainer().withDockerSocket(true);
 ```
 
 ### Container Properties

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/FlociContainer.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/FlociContainer.java
@@ -1,5 +1,6 @@
 package io.floci.testcontainers;
 
+import com.github.dockerjava.api.model.Bind;
 import io.floci.testcontainers.config.*;
 import io.floci.testcontainers.config.services.*;
 import org.slf4j.Logger;
@@ -20,6 +21,7 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -31,10 +33,12 @@ import java.util.function.Supplier;
  * <p>Starts a Floci container that exposes all emulated AWS services on a single HTTP
  * endpoint. Use {@link #getEndpoint()} to obtain the URL for configuring AWS SDK clients.
  *
- * <p>Container-based services (RDS, ElastiCache, Lambda, ECS) require access to the Docker
- * daemon. This module automatically mounts the Docker socket and runs as root to enable
- * these services. Sibling containers created by Floci (e.g. PostgreSQL for RDS) are
- * accessible on the Docker host via their mapped ports.
+ * <p>Container-based services (RDS, ElastiCache, Lambda, ECS, and others) require access to the
+ * Docker daemon. This module automatically mounts the Docker socket only when at least one
+ * currently enabled service actually needs it.
+ * Sibling containers created by Floci (e.g. PostgreSQL for RDS) are accessible on the Docker
+ * host via their mapped ports. Use {@link #withDockerSocket(boolean)} to override this
+ * auto-detection, e.g. to opt out entirely regardless of which services are enabled.
  *
  * <pre>{@code
  * try (FlociContainer floci = new FlociContainer()) {
@@ -64,6 +68,9 @@ public class FlociContainer extends GenericContainer<FlociContainer> {
     private static final String DEFAULT_ACCOUNT_ID = "000000000000";
     private static final String DEFAULT_ACCESS_KEY = "test";
     private static final String DEFAULT_SECRET_KEY = "test";
+
+    // explicit override from withDockerSocket(), which takes full precedence of auto-detection mode
+    private Boolean dockerSocketOverride;
 
     private TlsConfig tlsConfig = TlsConfig.builder().build();
     private StorageConfig storageConfig = StorageConfig.builder().build();
@@ -261,9 +268,6 @@ public class FlociContainer extends GenericContainer<FlociContainer> {
         super(dockerImageName);
         dockerImageName.assertCompatibleWith(DEFAULT_IMAGE_NAME);
 
-        // Allow creation of child container instances (e.g. for ECS or RDS service)
-        withFileSystemBind(DockerClientFactory.instance().getRemoteDockerUnixSocketPath(), DOCKER_SOCKET_PATH);
-
         // Configure observability and healthcheck
         withLogLevel(Level.WARN);
         waitingFor(Wait.forHttp("/_floci/init")
@@ -275,6 +279,31 @@ public class FlociContainer extends GenericContainer<FlociContainer> {
         // Configure ports and env vars
         configureExposedPorts();
         configureEnvVars();
+    }
+
+    /**
+     * Finalizes container configuration right before creation, once every {@code with*Config(...)} call
+     * the caller is going to make has already happened. Used to conditionally mount the Docker socket
+     * (see {@link #shouldBindDockerSocket()}), since that decision depends on the final state of all
+     * service configurations rather than any single one of them.
+     */
+    @Override
+    protected void configure() {
+        super.configure();
+
+        Optional<Bind> dockerSocketBinding = findDockerSocketBinding();
+        if (shouldBindDockerSocket()) {
+            if (dockerSocketBinding.isEmpty()) {
+                // Allow creation of child container instances (e.g. for ECS or RDS service)
+                withFileSystemBind(DockerClientFactory.instance().getRemoteDockerUnixSocketPath(), DOCKER_SOCKET_PATH);
+            }
+        } else {
+            dockerSocketBinding.ifPresent(bind -> getBinds().remove(bind));
+
+            if (isDockerSocketRequiredByServices()) {
+                logger().warn("There are services requiring a Docker socket, but the FlociContainer is configured to not mount it. This may cause failures in those services.");
+            }
+        }
     }
 
     @Override
@@ -443,6 +472,32 @@ public class FlociContainer extends GenericContainer<FlociContainer> {
         serviceConfigAccessors.forEach(ServiceConfigAccessor::disable);
         configureExposedPorts();
         configureEnvVars();
+        return this;
+    }
+
+    /**
+     * Overrides whether the host Docker socket is mounted into the container, bypassing auto-detection.
+     *
+     * <p>By default (this method never called), the socket is mounted only if at least one currently
+     * enabled service actually needs it (e.g. RDS, Lambda, ElastiCache — see
+     * {@link io.floci.testcontainers.config.services.AbstractServiceConfig#requiresDockerSocket()}).
+     * Calling this method overrides that auto-detection entirely, regardless of which services are
+     * enabled:
+     *
+     * <ul>
+     *     <li>{@code withDockerSocket(false)} — never mount the socket. Useful on hosts where mounting
+     *     it is broken or undesired (e.g. rootless Podman with SELinux, see
+     *     <a href="https://github.com/floci-io/testcontainers-floci/issues/223">#223</a>) and no
+     *     Docker-backed service is actually required.</li>
+     *     <li>{@code withDockerSocket(true)} — always mount the socket, even if no currently enabled
+     *     service is detected as needing it.</li>
+     * </ul>
+     *
+     * @param enabled {@code true} to always mount the Docker socket, {@code false} to never mount it
+     * @return this container instance
+     */
+    public FlociContainer withDockerSocket(boolean enabled) {
+        this.dockerSocketOverride = enabled;
         return this;
     }
 
@@ -3026,6 +3081,35 @@ public class FlociContainer extends GenericContainer<FlociContainer> {
 
         // Services config
         serviceConfigAccessors.forEach(accessor -> accessor.get().applyEnvVarsToContainer(this));
+    }
+
+    /**
+     * Determines whether the Docker socket should be mounted: an explicit {@link #withDockerSocket(boolean)}
+     * override always wins; otherwise falls back to {@link #isDockerSocketRequiredByServices()}.
+     *
+     * @return {@code true} if the Docker socket should be mounted
+     */
+    private boolean shouldBindDockerSocket() {
+        return dockerSocketOverride != null ? dockerSocketOverride : isDockerSocketRequiredByServices();
+    }
+
+    /**
+     * Returns whether any currently enabled service configuration needs access to the Docker socket
+     * (see {@link io.floci.testcontainers.config.services.AbstractServiceConfig#requiresDockerSocket()}).
+     *
+     * @return {@code true} if at least one enabled service requires the Docker socket
+     */
+    private boolean isDockerSocketRequiredByServices() {
+        return serviceConfigAccessors.stream().anyMatch(accessor -> accessor.get().requiresDockerSocket());
+    }
+
+    /**
+     * Returns the binding configuration for the Docker socket, if it is mounted into the container.
+     *
+     * @return an {@link Optional} containing the binding configuration, or {@link Optional#empty()} if not mounted
+     */
+    private Optional<Bind> findDockerSocketBinding() {
+        return getBinds().stream().filter(b -> DOCKER_SOCKET_PATH.equals(b.getVolume().getPath())).findFirst();
     }
 
     private static String uniqueShortId() {

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/AbstractServiceConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/AbstractServiceConfig.java
@@ -63,4 +63,19 @@ public abstract class AbstractServiceConfig<B extends AbstractServiceConfigBuild
      */
     public void applyExposedPortsToContainer(Container<?> container) {
     }
+
+    /**
+     * Returns whether this service, as currently configured, needs access to the host Docker socket to
+     * create sibling containers (e.g. RDS spinning up a PostgreSQL container, Lambda invoking functions
+     * in child containers).
+     *
+     * <p>Defaults to {@code false}. Docker-backed services override this to return {@code true} while
+     * {@linkplain #isEnabled() enabled} (and, for services that support a docker-less {@code mock} mode,
+     * only while not running in that mode).
+     *
+     * @return {@code true} if this service requires the Docker socket to be mounted
+     */
+    public boolean requiresDockerSocket() {
+        return false;
+    }
 }

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/AmazonMqConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/AmazonMqConfig.java
@@ -76,6 +76,11 @@ public class AmazonMqConfig extends AbstractServiceConfig<AmazonMqConfig.Builder
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link AmazonMqConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/AthenaConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/AthenaConfig.java
@@ -61,6 +61,11 @@ public class AthenaConfig extends AbstractServiceConfig<AthenaConfig.Builder> {
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link AthenaConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/BatchConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/BatchConfig.java
@@ -78,6 +78,11 @@ public class BatchConfig extends AbstractServiceConfig<BatchConfig.Builder> {
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled();
+    }
+
     /**
      * Builder for {@link BatchConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/CodeBuildConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/CodeBuildConfig.java
@@ -58,6 +58,11 @@ public class CodeBuildConfig extends AbstractServiceConfig<CodeBuildConfig.Build
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled();
+    }
+
     /**
      * Builder for {@link CodeBuildConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/DocumentDbConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/DocumentDbConfig.java
@@ -92,6 +92,11 @@ public class DocumentDbConfig extends AbstractServiceConfig<DocumentDbConfig.Bui
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link DocumentDbConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/Ec2Config.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/Ec2Config.java
@@ -222,6 +222,11 @@ public class Ec2Config extends AbstractServiceConfig<Ec2Config.Builder> {
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link Ec2Config}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/EcrConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/EcrConfig.java
@@ -162,6 +162,11 @@ public class EcrConfig extends AbstractServiceConfig<EcrConfig.Builder> {
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled();
+    }
+
     /**
      * Builder for {@link EcrConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/EcsConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/EcsConfig.java
@@ -104,6 +104,11 @@ public class EcsConfig extends AbstractServiceConfig<EcsConfig.Builder> {
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link EcsConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/EksConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/EksConfig.java
@@ -222,6 +222,11 @@ public class EksConfig extends AbstractServiceConfig<EksConfig.Builder> {
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link EksConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/ElastiCacheConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/ElastiCacheConfig.java
@@ -135,6 +135,11 @@ public class ElastiCacheConfig extends AbstractServiceConfig<ElastiCacheConfig.B
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled();
+    }
+
     /**
      * Builder for {@link ElastiCacheConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/KinesisAnalyticsConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/KinesisAnalyticsConfig.java
@@ -80,6 +80,11 @@ public class KinesisAnalyticsConfig extends AbstractServiceConfig<KinesisAnalyti
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link KinesisAnalyticsConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/LambdaConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/LambdaConfig.java
@@ -333,6 +333,11 @@ public class LambdaConfig extends AbstractServiceConfig<LambdaConfig.Builder> {
         Optional<List<String>> allowedPaths();
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled();
+    }
+
     /**
      * Builder for {@link LambdaConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/MemoryDbConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/MemoryDbConfig.java
@@ -139,6 +139,11 @@ public class MemoryDbConfig extends AbstractServiceConfig<MemoryDbConfig.Builder
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link MemoryDbConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/MskConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/MskConfig.java
@@ -122,6 +122,11 @@ public class MskConfig extends AbstractServiceConfig<MskConfig.Builder> {
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link MskConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/MwaaConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/MwaaConfig.java
@@ -207,6 +207,11 @@ public class MwaaConfig extends AbstractServiceConfig<MwaaConfig.Builder> {
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link MwaaConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/NeptuneConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/NeptuneConfig.java
@@ -151,6 +151,11 @@ public class NeptuneConfig extends AbstractServiceConfig<NeptuneConfig.Builder> 
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled();
+    }
+
     /**
      * Builder for {@link NeptuneConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/OpenSearchConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/OpenSearchConfig.java
@@ -129,6 +129,11 @@ public class OpenSearchConfig extends AbstractServiceConfig<OpenSearchConfig.Bui
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link OpenSearchConfig}.
      */

--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/RdsConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/RdsConfig.java
@@ -186,6 +186,11 @@ public class RdsConfig extends AbstractServiceConfig<RdsConfig.Builder> {
         }
     }
 
+    @Override
+    public boolean requiresDockerSocket() {
+        return isEnabled() && !mock;
+    }
+
     /**
      * Builder for {@link RdsConfig}.
      */

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/FlociContainerTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/FlociContainerTest.java
@@ -265,5 +265,119 @@ class FlociContainerTest {
         }
     }
 
+    @Test
+    void shouldRequireDockerSocketByDefault() {
+        try (FlociContainer container = new FlociContainer()) {
+            container.configure();
 
+            assertThat(container.getBinds())
+                    .anyMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+        }
+    }
+
+    @Test
+    void shouldNotBindDockerSocketWhenNoDockerBackedServiceIsEnabled() {
+        try (FlociContainer container = new FlociContainer().disableAllServices()) {
+            container.configure();
+            assertThat(container.getBinds())
+                    .noneMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+        }
+    }
+
+    @Test
+    void shouldBindDockerSocketOnlyOnceWhenConfiguredRepeatedly() {
+        try (FlociContainer container = new FlociContainer()) {
+            container.configure();
+            container.configure();
+
+            assertThat(container.getBinds())
+                    .filteredOn(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()))
+                    .hasSize(1);
+        }
+    }
+
+    @Test
+    void shouldNotRequireDockerSocketWhenNoDockerBackedServiceIsEnabled() {
+        try (FlociContainer container = new FlociContainer().disableAllServices()) {
+            container.withS3Config(c -> c.enabled(true))
+                    .configure();
+
+            assertThat(container.getBinds())
+                    .noneMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+        }
+    }
+
+    @Test
+    void shouldNotRequireDockerSocketWhenDockerBackedServiceIsMocked() {
+        try (FlociContainer container = new FlociContainer().disableAllServices()) {
+            container.withRdsConfig(c -> c.enabled(true).mock(true))
+                    .configure();
+
+            assertThat(container.getBinds())
+                    .noneMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+        }
+    }
+
+    @Test
+    void shouldRequireDockerSocketWhenDockerBackedServiceIsEnabledAndNotMocked() {
+        try (FlociContainer container = new FlociContainer().disableAllServices()) {
+            container.withRdsConfig(c -> c.enabled(true).mock(false))
+                    .configure();
+
+            assertThat(container.getBinds())
+                    .anyMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+        }
+    }
+
+    @Test
+    void shouldOverrideAutoDetectionWhenDockerSocketExplicitlyEnabled() {
+        try (FlociContainer container = new FlociContainer().disableAllServices()) {
+            container.withDockerSocket(true)
+                    .configure();
+
+            assertThat(container.getBinds())
+                    .anyMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+        }
+    }
+
+    @Test
+    void shouldOverrideAutoDetectionWhenDockerSocketExplicitlyDisabled() {
+        try (FlociContainer container = new FlociContainer()) {
+            container.withDockerSocket(false)
+                    .configure();
+
+            assertThat(container.getBinds())
+                    .noneMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+        }
+    }
+
+    @Test
+    void shouldUnbindDockerSocketWhenConfigChangesAfterRestart() {
+        try (FlociContainer container = new FlociContainer()) {
+            container.configure();
+
+            assertThat(container.getBinds())
+                    .anyMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+
+            container.disableAllServices().configure();
+
+            assertThat(container.getBinds())
+                    .noneMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+        }
+    }
+
+    @Test
+    void shouldBindDockerSocketWhenConfigChangesAfterRestart() {
+        try (FlociContainer container = new FlociContainer()) {
+            container.disableAllServices().configure();
+
+            assertThat(container.getBinds())
+                    .noneMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+
+            container.withDockerSocket(true).configure();
+
+            assertThat(container.getBinds())
+                    .anyMatch(b -> "/var/run/docker.sock".equals(b.getVolume().getPath()));
+        }
+    }
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/AmazonMqConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/AmazonMqConfigTest.java
@@ -78,4 +78,11 @@ class AmazonMqConfigTest {
         assertThat(copy.getDefaultImage()).isEqualTo("test-image");
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(AmazonMqConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(AmazonMqConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(AmazonMqConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/AthenaConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/AthenaConfigTest.java
@@ -68,4 +68,11 @@ class AthenaConfigTest {
         assertThat(copy.isMock()).isTrue();
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(AthenaConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(AthenaConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(AthenaConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/BatchConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/BatchConfigTest.java
@@ -78,4 +78,10 @@ class BatchConfigTest {
         assertThat(copy.getDockerNetwork()).isEqualTo("test-network");
     }
 
+    @Test
+    void shouldRequireDockerSocketWhenEnabled() {
+        assertThat(BatchConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(BatchConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/CodeBuildConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/CodeBuildConfigTest.java
@@ -68,4 +68,10 @@ class CodeBuildConfigTest {
         assertThat(copy.getDockerNetwork()).isEqualTo("test-network");
     }
 
+    @Test
+    void shouldRequireDockerSocketWhenEnabled() {
+        assertThat(CodeBuildConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(CodeBuildConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/DocumentDbConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/DocumentDbConfigTest.java
@@ -86,4 +86,11 @@ class DocumentDbConfigTest {
         assertThat(copy.getDockerNetwork()).isEqualTo("test-network");
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(DocumentDbConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(DocumentDbConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(DocumentDbConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/Ec2ConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/Ec2ConfigTest.java
@@ -182,4 +182,11 @@ class Ec2ConfigTest {
         assertThat(copy.getAutoScaling().enabled()).isFalse();
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(Ec2Config.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(Ec2Config.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(Ec2Config.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/EcrConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/EcrConfigTest.java
@@ -129,4 +129,10 @@ class EcrConfigTest {
         assertThat(copy.getDockerNetwork()).isEqualTo("test-network");
     }
 
+    @Test
+    void shouldRequireDockerSocketWhenEnabled() {
+        assertThat(EcrConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(EcrConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/EcsConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/EcsConfigTest.java
@@ -92,4 +92,11 @@ class EcsConfigTest {
         assertThat(copy.getDefaultCpuUnits()).isEqualTo(512);
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(EcsConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(EcsConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(EcsConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/EksConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/EksConfigTest.java
@@ -155,4 +155,11 @@ class EksConfigTest {
         assertThat(copy.isDisableCni()).isTrue();
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(EksConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(EksConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(EksConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/ElastiCacheConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/ElastiCacheConfigTest.java
@@ -111,4 +111,10 @@ class ElastiCacheConfigTest {
         assertThat(copy.getDockerNetwork()).isEqualTo("test-network");
     }
 
+    @Test
+    void shouldRequireDockerSocketWhenEnabled() {
+        assertThat(ElastiCacheConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(ElastiCacheConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/KinesisAnalyticsConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/KinesisAnalyticsConfigTest.java
@@ -77,4 +77,11 @@ class KinesisAnalyticsConfigTest {
         assertThat(copy.getDefaultImage()).contains("apache/flink:1.20");
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(KinesisAnalyticsConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(KinesisAnalyticsConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(KinesisAnalyticsConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/LambdaConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/LambdaConfigTest.java
@@ -305,4 +305,10 @@ class LambdaConfigTest {
         assertThat(copy.getContainerNamePrefix()).contains("acme-prefix");
     }
 
+    @Test
+    void shouldRequireDockerSocketWhenEnabled() {
+        assertThat(LambdaConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(LambdaConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/MemoryDbConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/MemoryDbConfigTest.java
@@ -121,4 +121,11 @@ class MemoryDbConfigTest {
         assertThat(copy.getDockerNetwork()).contains("test-network");
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(MemoryDbConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(MemoryDbConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(MemoryDbConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/MskConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/MskConfigTest.java
@@ -108,4 +108,11 @@ class MskConfigTest {
         assertThat(copy.getKafkaHostPortsCount()).isEqualTo(5);
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(MskConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(MskConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(MskConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/MwaaConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/MwaaConfigTest.java
@@ -130,4 +130,11 @@ class MwaaConfigTest {
         assertThat(copy.getDockerNetwork()).contains("my-mwaa-network");
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(MwaaConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(MwaaConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(MwaaConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/NeptuneConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/NeptuneConfigTest.java
@@ -119,4 +119,10 @@ class NeptuneConfigTest {
         assertThat(copy.getDockerNetwork()).isEqualTo("test-network");
     }
 
+    @Test
+    void shouldRequireDockerSocketWhenEnabled() {
+        assertThat(NeptuneConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(NeptuneConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/OpenSearchConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/OpenSearchConfigTest.java
@@ -99,4 +99,11 @@ class OpenSearchConfigTest {
         assertThat(copy.getDockerNetwork()).isEqualTo("test-network");
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(OpenSearchConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(OpenSearchConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(OpenSearchConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/RdsConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/RdsConfigTest.java
@@ -127,4 +127,11 @@ class RdsConfigTest {
         assertThat(copy.getEndpointHost()).isEqualTo("test-host");
     }
 
+    @Test
+    void shouldRequireDockerSocketOnlyWhenEnabledAndNotMocked() {
+        assertThat(RdsConfig.builder().build().requiresDockerSocket()).isTrue();
+        assertThat(RdsConfig.builder().enabled(false).build().requiresDockerSocket()).isFalse();
+        assertThat(RdsConfig.builder().mock(true).build().requiresDockerSocket()).isFalse();
+    }
+
 }


### PR DESCRIPTION
## Summary

FlociContainer's constructor unconditionally bound the host Docker socket, even when no enabled service actually used it. On rootless Podman with SELinux enforcing, the implicit :z relabel that Testcontainers adds to that bind fails with EPERM because a rootless user cannot relabel the root-owned socket.

The socket is now mounted lazily, in an overridden configure() (which runs once right before container creation, after all with*Config(...) calls), based on whether any currently enabled service reports requiresDockerSocket(). AbstractServiceConfig.requiresDockerSocket() defaults to false; the docker-backed services (RDS, Lambda, ElastiCache, ECS, OpenSearch, EKS, DocumentDB, MemoryDB, Neptune, MWAA, Batch, CodeBuild, ECR, MSK, EC2, Amazon MQ, Kinesis Analytics) override it to true while enabled (and, for the ones with a docker-less mock mode, only while not mocked).

A new withDockerSocket(boolean) method overrides this auto-detection entirely, regardless of which services are enabled or mocked - withDockerSocket(false) is the escape hatch for hosts where mounting the socket doesn't work (e.g. rootless Podman) and no Docker-backed service is needed; withDockerSocket(true) forces the mount even when none is detected as required.

## Related issue

Fixes #223

## Type of change

<!-- Check the one that applies. -->

- [x] Bug fix (`fix:` commit)
- [ ] New feature (`feat:` commit)
- [ ] Breaking change (`feat!:` commit or `BREAKING CHANGE:` footer)
- [ ] Documentation or chore

## Checklist

- [x] `mvn verify` passes locally (requires Docker)
- [x] New or changed behaviour is covered by tests
- [x] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
