### PR TITLE
fix: avoid conflicts with Spring Cloud AWS Testcontainers >= v4.1.0

### DIFF
--- a/spring-boot-testcontainers-floci/src/main/java/io/floci/testcontainers/spring/FlociAwsContainerConnectionDetailsFactory.java
+++ b/spring-boot-testcontainers-floci/src/main/java/io/floci/testcontainers/spring/FlociAwsContainerConnectionDetailsFactory.java
@@ -2,9 +2,11 @@ package io.floci.testcontainers.spring;
 
 import io.awspring.cloud.autoconfigure.core.AwsConnectionDetails;
 import io.floci.testcontainers.FlociContainer;
-import java.net.URI;
 import org.springframework.boot.testcontainers.service.connection.ContainerConnectionDetailsFactory;
 import org.springframework.boot.testcontainers.service.connection.ContainerConnectionSource;
+import org.springframework.util.ClassUtils;
+
+import java.net.URI;
 
 /**
  * {@link ContainerConnectionDetailsFactory} that produces {@link AwsConnectionDetails}
@@ -20,12 +22,23 @@ import org.springframework.boot.testcontainers.service.connection.ContainerConne
 public class FlociAwsContainerConnectionDetailsFactory
         extends ContainerConnectionDetailsFactory<FlociContainer, AwsConnectionDetails> {
 
+    private static final boolean IS_SPRING_AWS_PRESENT = ClassUtils.isPresent(
+            "io.awspring.cloud.testcontainers.AwsFlociContainerConnectionDetailsFactory",
+            FlociAwsContainerConnectionDetailsFactory.class.getClassLoader()
+    );
+
+
     FlociAwsContainerConnectionDetailsFactory() {
     }
 
     @Override
     protected AwsConnectionDetails getContainerConnectionDetails(
             ContainerConnectionSource<FlociContainer> source) {
+        // If the Spring Cloud AWS Testcontainers support is present, skip our implementation
+        if (IS_SPRING_AWS_PRESENT) {
+            return null;
+        }
+
         return new FlociAwsContainerConnectionDetails(source);
     }
 


### PR DESCRIPTION
## Summary
Fixes an incompatibility with Spring Cloud AWS Testcontainers library, which also registers a ConnectionDetailsFactory for AwsConnectionDetails.

## Related issue

Fixes #378

## Type of change

<!-- Check the one that applies. -->

- [x] Bug fix (`fix:` commit)
- [ ] New feature (`feat:` commit)
- [ ] Breaking change (`feat!:` commit or `BREAKING CHANGE:` footer)
- [ ] Documentation or chore

## Checklist

- [x] `mvn verify` passes locally (requires Docker)
- [ ] New or changed behaviour is covered by tests --> hard to test without permanently adding a dependency to Spring Cloud AWS Testcontainers
- [x] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
