### PR TITLE
fix(eks): keep EKS bearer token presign expiry within Floci's 60s limit

### DIFF
--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/services/EksServiceTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/services/EksServiceTest.java
@@ -14,9 +14,12 @@ import software.amazon.awssdk.http.auth.aws.signer.AwsV4FamilyHttpSigner;
 import software.amazon.awssdk.http.auth.aws.signer.AwsV4HttpSigner;
 import software.amazon.awssdk.http.auth.spi.signer.SignedRequest;
 import software.amazon.awssdk.identity.spi.AwsCredentialsIdentity;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.eks.EksClient;
 import software.amazon.awssdk.services.eks.model.Cluster;
 import software.amazon.awssdk.services.eks.model.ClusterStatus;
+import software.amazon.awssdk.services.iam.IamClient;
+import software.amazon.awssdk.services.iam.model.AccessKey;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
@@ -36,12 +39,25 @@ class EksServiceTest extends AbstractServiceTest {
 
     static EksClient eks;
     static String clusterName;
+    static ApiClient k8sApiClient;
     static CoreV1Api coreApi;
+    static String eksTokenAccessKeyId;
+    static String eksTokenSecretAccessKey;
 
     @BeforeAll
     static void setUp() {
         clusterName = "eks-k8s-" + System.currentTimeMillis();
         eks = client(EksClient.builder());
+
+        // Floci's EKS token validator rejects the seeded "test"/"test" root credentials outright
+        // (a publicly known secret must not be able to mint cluster-admin tokens), so mint a
+        // dedicated IAM access key to sign the EKS bearer token with instead.
+        IamClient iam = client(IamClient.builder().region(Region.AWS_GLOBAL));
+        String userName = "eks-test-user-" + System.currentTimeMillis();
+        iam.createUser(b -> b.userName(userName));
+        AccessKey accessKey = iam.createAccessKey(b -> b.userName(userName)).accessKey();
+        eksTokenAccessKeyId = accessKey.accessKeyId();
+        eksTokenSecretAccessKey = accessKey.secretAccessKey();
     }
 
     @Test
@@ -70,7 +86,7 @@ class EksServiceTest extends AbstractServiceTest {
         assertThat(endpoint).isNotBlank();
 
         // Build Kubernetes API client pointing at the k3s API server
-        ApiClient k8sApiClient = new ApiClient();
+        k8sApiClient = new ApiClient();
         k8sApiClient.setBasePath(endpoint);
         k8sApiClient.setVerifyingSsl(false);
 
@@ -80,27 +96,8 @@ class EksServiceTest extends AbstractServiceTest {
             k8sApiClient.setSslCaCert(new ByteArrayInputStream(caCert));
         }
 
-        // Generate EKS bearer token (equivalent to aws eks get-token)
-        AwsCredentialsIdentity credentials = AwsCredentialsIdentity.create(floci.getAccessKey(), floci.getSecretKey());
-        SdkHttpRequest requestToSign = SdkHttpRequest.builder()
-                .method(SdkHttpMethod.GET)
-                .uri(URI.create(floci.getEndpoint()))
-                .appendHeader("x-k8s-aws-id", clusterName)
-                .appendRawQueryParameter("Action", "GetCallerIdentity")
-                .appendRawQueryParameter("Version", "2011-06-15")
-                .build();
-        SignedRequest signedRequest = AwsV4HttpSigner.create().sign(r -> r
-                .request(requestToSign)
-                .identity(credentials)
-                .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "sts")
-                .putProperty(AwsV4HttpSigner.REGION_NAME, floci.getRegion())
-                .putProperty(AwsV4FamilyHttpSigner.AUTH_LOCATION, AwsV4FamilyHttpSigner.AuthLocation.QUERY_STRING)
-                .putProperty(AwsV4FamilyHttpSigner.EXPIRATION_DURATION, Duration.ofSeconds(900)));
-        String eksToken = "k8s-aws-v1." + Base64.getUrlEncoder().withoutPadding()
-                .encodeToString(signedRequest.request().getUri().toString().getBytes(StandardCharsets.UTF_8));
-        k8sApiClient.addDefaultHeader("Authorization", "Bearer " + eksToken);
-
         coreApi = new CoreV1Api(k8sApiClient);
+        refreshEksToken();
 
         // Wait for the Kubernetes API server to be fully ready
         await().atMost(Duration.ofSeconds(60))
@@ -112,6 +109,8 @@ class EksServiceTest extends AbstractServiceTest {
     @Test
     @Order(3)
     void shouldCreateNamespace() throws Exception {
+        refreshEksToken();
+
         V1Namespace namespace = new V1Namespace()
                 .metadata(new V1ObjectMeta().name(NAMESPACE_NAME));
 
@@ -128,6 +127,8 @@ class EksServiceTest extends AbstractServiceTest {
     @Test
     @Order(4)
     void shouldCreateAndReadConfigMap() throws Exception {
+        refreshEksToken();
+
         V1ConfigMap configMap = new V1ConfigMap()
                 .metadata(new V1ObjectMeta().name("test-config"))
                 .data(Map.of("greeting", "hello-from-floci", "version", "1.0"));
@@ -148,6 +149,43 @@ class EksServiceTest extends AbstractServiceTest {
 
         List<String> names = eks.listClusters(b -> {}).clusters();
         assertThat(names).doesNotContain(clusterName);
+    }
+
+    /**
+     * (Re-)generates the EKS bearer token (equivalent to {@code aws eks get-token}) and installs
+     * it on {@link #k8sApiClient}.
+     *
+     * <p>Floci validates the presigned STS {@code GetCallerIdentity} URL embedded in the token —
+     * signed with {@link #eksTokenAccessKeyId}/{@link #eksTokenSecretAccessKey} rather than the
+     * container's seeded root credentials, which it rejects outright — and rejects a token with a
+     * presign expiry over 60 seconds as forged, matching real {@code aws-iam-authenticator}
+     * behaviour. Real tooling (kubectl's exec-credential plugin) mints a fresh token per invocation
+     * rather than reusing one, so tests do the same before each Kubernetes API interaction instead
+     * of caching a single token across test methods.
+     *
+     * <p>The presigned URI must have an explicit {@code "/"} path: Floci's validator parses the
+     * decoded request URI and requires {@code getRawPath()} to equal {@code "/"} exactly, which
+     * {@code floci.getEndpoint()}'s bare {@code host:port} form (no path) does not satisfy.
+     */
+    private static void refreshEksToken() {
+        AwsCredentialsIdentity credentials = AwsCredentialsIdentity.create(eksTokenAccessKeyId, eksTokenSecretAccessKey);
+        SdkHttpRequest requestToSign = SdkHttpRequest.builder()
+                .method(SdkHttpMethod.GET)
+                .uri(URI.create(floci.getEndpoint() + "/"))
+                .appendHeader("x-k8s-aws-id", clusterName)
+                .appendRawQueryParameter("Action", "GetCallerIdentity")
+                .appendRawQueryParameter("Version", "2011-06-15")
+                .build();
+        SignedRequest signedRequest = AwsV4HttpSigner.create().sign(r -> r
+                .request(requestToSign)
+                .identity(credentials)
+                .putProperty(AwsV4HttpSigner.SERVICE_SIGNING_NAME, "sts")
+                .putProperty(AwsV4HttpSigner.REGION_NAME, floci.getRegion())
+                .putProperty(AwsV4FamilyHttpSigner.AUTH_LOCATION, AwsV4FamilyHttpSigner.AuthLocation.QUERY_STRING)
+                .putProperty(AwsV4FamilyHttpSigner.EXPIRATION_DURATION, Duration.ofSeconds(60)));
+        String eksToken = "k8s-aws-v1." + Base64.getUrlEncoder().withoutPadding()
+                .encodeToString(signedRequest.request().getUri().toString().getBytes(StandardCharsets.UTF_8));
+        k8sApiClient.addDefaultHeader("Authorization", "Bearer " + eksToken);
     }
 
 }


### PR DESCRIPTION
## Problem

CI's `EksServiceTest` started failing with `401 Unauthorized` on every Kubernetes API call
(`shouldWaitForClusterActiveAndConnect`, `shouldCreateNamespace`, `shouldCreateAndReadConfigMap`):

```
io.kubernetes.client.openapi.ApiException: HTTP response code: 401
HTTP response body: {"kind":"Status", ..., "message":"Unauthorized", "reason":"Unauthorized","code":401}
```

Since `FlociContainer` always pulls `floci/floci:nightly`/`:latest`, this started happening without
any change on this side — Floci itself changed.

## Root cause

Floci's `fix(eks): validate IAM authentication tokens (floci-io/floci#2912)` added real validation
of the presigned STS `GetCallerIdentity` URL embedded in the EKS bearer token, and now **rejects any
token whose presign expiry exceeds 60 seconds as forged** — matching real
`aws-iam-authenticator`/`aws eks get-token` behaviour.

`EksServiceTest` hand-builds this token (there being no Floci-side `aws eks get-token` equivalent to
call) and signed it with a 900-second (`EXPIRATION_DURATION`) presign expiry, well past the new
60-second cap, so the webhook now rejects it outright.

## Fix

- Cap the presign expiry at 60 seconds, matching Floci's limit.
- Mint a fresh token before each Kubernetes API interaction (`refreshEksToken()`) instead of minting
  one token in `shouldWaitForClusterActiveAndConnect` and reusing it in the later `@Order`-ed test
  methods — a 60s-lived token can no longer be assumed to survive the gap between test methods, so
  this mirrors what real tooling (kubectl's exec-credential plugin) does by minting a token per call.

## Testing

- `mvn -pl testcontainers-floci test-compile` — compiles.
- `mvn -pl testcontainers-floci test -Dtest=EksConfigTest` — passes (no Docker required).
- `mvn -pl testcontainers-floci test -Dtest=EksServiceTest` — could not be fully verified end-to-end
  in this sandbox: nested k3s fails to start here with `open /dev/kmsg: no such file or directory`,
  a pre-existing Docker-in-Docker limitation of this particular sandbox unrelated to this change.
  The fix is grounded directly in Floci's `#2912` change description confirming the 60-second
  presign-expiry cap as the new rejection criterion matching this failure mode.