### PR TITLE
fix(controltower): create a landing zone in ControlTowerServiceTest

### DIFF
--- a/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/ControlTowerConfig.java
+++ b/testcontainers-floci/src/main/java/io/floci/testcontainers/config/services/ControlTowerConfig.java
@@ -8,13 +8,20 @@ import org.testcontainers.containers.Container;
  * <p>Instances are created via {@link Builder}:
  * <pre>{@code
  * ControlTowerConfig config = ControlTowerConfig.builder()
+ *     .seedLandingZone(true)
  *     .build();
  * }</pre>
  */
 public class ControlTowerConfig extends AbstractServiceConfig<ControlTowerConfig.Builder> {
 
+    /** Default value for the {@link #hasSeedLandingZone()} flag. */
+    private static final boolean DEFAULT_SEED_LANDING_ZONE = false;
+
+    private final boolean seedLandingZone;
+
     private ControlTowerConfig(Builder builder) {
         super(builder.enabled);
+        this.seedLandingZone = builder.seedLandingZone;
     }
 
     /**
@@ -37,15 +44,34 @@ public class ControlTowerConfig extends AbstractServiceConfig<ControlTowerConfig
         return new Builder(this);
     }
 
+    /**
+     * Returns whether a landing zone should be seeded at startup.
+     *
+     * <p>Floci's normal runtime starts with no landing zone, so {@code ListLandingZones} returns
+     * an empty list until {@code CreateLandingZone} is called. Enabling this restores the
+     * deterministic seeded landing-zone fixture.
+     *
+     * @return {@code true} if a landing zone should be seeded
+     */
+    public boolean hasSeedLandingZone() {
+        return seedLandingZone;
+    }
+
     @Override
     public void applyEnvVarsToContainer(Container<?> container) {
         container.withEnv("FLOCI_SERVICES_CONTROLTOWER_ENABLED", String.valueOf(isEnabled()));
+
+        if (isEnabled()) {
+            container.withEnv("FLOCI_SERVICES_CONTROLTOWER_SEED_LANDING_ZONE", String.valueOf(seedLandingZone));
+        }
     }
 
     /**
      * Builder for {@link ControlTowerConfig}.
      */
     public static class Builder extends AbstractServiceConfigBuilder<Builder, ControlTowerConfig> {
+
+        private boolean seedLandingZone = DEFAULT_SEED_LANDING_ZONE;
 
         private Builder() {
             // Allow instantiation only via ControlTowerConfig.builder()
@@ -58,6 +84,18 @@ public class ControlTowerConfig extends AbstractServiceConfig<ControlTowerConfig
          */
         private Builder(ControlTowerConfig instance) {
             super(instance);
+            this.seedLandingZone = instance.hasSeedLandingZone();
+        }
+
+        /**
+         * Enables or disables seeding a landing zone at startup.
+         *
+         * @param seedLandingZone {@code true} to seed a landing zone (default {@value DEFAULT_SEED_LANDING_ZONE})
+         * @return this builder
+         */
+        public Builder seedLandingZone(boolean seedLandingZone) {
+            this.seedLandingZone = seedLandingZone;
+            return this;
         }
 
         /**

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/FlociContainerServicesConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/FlociContainerServicesConfigTest.java
@@ -745,9 +745,9 @@ class FlociContainerServicesConfigTest {
     @Test
     void shouldWireControlTowerConfigIntoContainer() {
         assertConfigWired(
-                c -> c.withControlTowerConfig(cfg -> cfg.enabled(false)),
-                c -> c.getControlTowerConfig().isEnabled(), false,
-                "FLOCI_SERVICES_CONTROLTOWER_ENABLED", "false");
+                c -> c.withControlTowerConfig(cfg -> cfg.seedLandingZone(true)),
+                c -> c.getControlTowerConfig().hasSeedLandingZone(), true,
+                "FLOCI_SERVICES_CONTROLTOWER_SEED_LANDING_ZONE", "true");
     }
 
     @Test

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/ControlTowerConfigTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/config/services/ControlTowerConfigTest.java
@@ -12,14 +12,17 @@ class ControlTowerConfigTest {
     void shouldApplyDefaultControlTowerConfig() {
         ControlTowerConfig config = ControlTowerConfig.builder().build();
         assertThat(config.isEnabled()).isTrue();
+        assertThat(config.hasSeedLandingZone()).isFalse();
     }
 
     @Test
     void shouldApplyCustomControlTowerConfig() {
         ControlTowerConfig config = ControlTowerConfig.builder()
                 .enabled(false)
+                .seedLandingZone(true)
                 .build();
         assertThat(config.isEnabled()).isFalse();
+        assertThat(config.hasSeedLandingZone()).isTrue();
     }
 
     @Test
@@ -27,7 +30,18 @@ class ControlTowerConfigTest {
         GenericContainer<?> container = genericContainer();
         ControlTowerConfig.builder().build().applyEnvVarsToContainer(container);
 
-        assertThat(container.getEnvMap()).containsEntry("FLOCI_SERVICES_CONTROLTOWER_ENABLED", "true");
+        assertThat(container.getEnvMap())
+                .containsEntry("FLOCI_SERVICES_CONTROLTOWER_ENABLED", "true")
+                .containsEntry("FLOCI_SERVICES_CONTROLTOWER_SEED_LANDING_ZONE", "false");
+    }
+
+    @Test
+    void shouldApplySeedLandingZoneEnvVarToContainer() {
+        GenericContainer<?> container = genericContainer();
+        ControlTowerConfig.builder().seedLandingZone(true).build().applyEnvVarsToContainer(container);
+
+        assertThat(container.getEnvMap())
+                .containsEntry("FLOCI_SERVICES_CONTROLTOWER_SEED_LANDING_ZONE", "true");
     }
 
     @Test
@@ -36,14 +50,17 @@ class ControlTowerConfigTest {
         ControlTowerConfig.builder().enabled(false).build().applyEnvVarsToContainer(container);
 
         assertThat(container.getEnvMap()).containsEntry("FLOCI_SERVICES_CONTROLTOWER_ENABLED", "false");
+        assertThat(container.getEnvMap()).doesNotContainKey("FLOCI_SERVICES_CONTROLTOWER_SEED_LANDING_ZONE");
     }
 
     @Test
     void shouldPreserveValuesOnToBuilder() {
         ControlTowerConfig config = ControlTowerConfig.builder()
                 .enabled(false)
+                .seedLandingZone(true)
                 .build();
         ControlTowerConfig copy = config.toBuilder().build();
         assertThat(copy.isEnabled()).isFalse();
+        assertThat(copy.hasSeedLandingZone()).isTrue();
     }
 }

--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/services/ControlTowerServiceTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/services/ControlTowerServiceTest.java
@@ -1,14 +1,28 @@
 package io.floci.testcontainers.services;
 
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import software.amazon.awssdk.core.document.Document;
 import software.amazon.awssdk.services.controltower.ControlTowerClient;
+import software.amazon.awssdk.services.controltower.model.LandingZoneSummary;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Floci no longer seeds a Control Tower landing zone; {@code ListLandingZones} stays empty until one
+ * is created. The tests are ordered: {@link #shouldCreateLandingZone()} provisions the landing zone
+ * the later tests read.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ControlTowerServiceTest extends AbstractServiceTest {
 
     static ControlTowerClient controlTower;
+
+    // Captured by shouldCreateLandingZone() and reused by the later, ordered tests.
+    static String landingZoneArn;
 
     @BeforeAll
     static void setUp() {
@@ -16,20 +30,47 @@ class ControlTowerServiceTest extends AbstractServiceTest {
     }
 
     @Test
-    void shouldListSeededLandingZone() {
-        var response = controlTower.listLandingZones(b -> {});
+    @Order(1)
+    void shouldCreateLandingZone() {
+        Document manifest = Document.mapBuilder()
+                .putDocument("governedRegions", Document.listBuilder().addString(floci.getRegion()).build())
+                .putDocument("securityRoles", Document.mapBuilder().putBoolean("enabled", true).build())
+                .putDocument("accessManagement", Document.mapBuilder().putBoolean("enabled", true).build())
+                .build();
 
-        assertThat(response.landingZones()).hasSize(1);
-        assertThat(response.landingZones().get(0).arn()).contains(":landingzone/");
+        var response = controlTower.createLandingZone(b -> b.version("4.0").manifest(manifest));
+
+        assertThat(response.arn()).contains(":landingzone/");
+        assertThat(response.operationIdentifier()).isNotBlank();
+
+        landingZoneArn = response.arn();
     }
 
     @Test
-    void shouldGetSeededLandingZone() {
-        String arn = controlTower.listLandingZones(b -> {}).landingZones().get(0).arn();
+    @Order(2)
+    void shouldListCreatedLandingZone() {
+        var response = controlTower.listLandingZones(b -> {});
 
-        var response = controlTower.getLandingZone(b -> b.landingZoneIdentifier(arn));
+        assertThat(response.landingZones())
+                .extracting(LandingZoneSummary::arn)
+                .containsExactly(landingZoneArn);
+    }
 
-        assertThat(response.landingZone().arn()).isEqualTo(arn);
+    @Test
+    @Order(3)
+    void shouldGetCreatedLandingZone() {
+        var response = controlTower.getLandingZone(b -> b.landingZoneIdentifier(landingZoneArn));
+
+        assertThat(response.landingZone().arn()).isEqualTo(landingZoneArn);
         assertThat(response.landingZone().status()).isNotNull();
+    }
+
+    @Test
+    @Order(4)
+    void shouldDeleteLandingZone() {
+        var response = controlTower.deleteLandingZone(b -> b.landingZoneIdentifier(landingZoneArn));
+
+        assertThat(response.operationIdentifier()).isNotBlank();
+        assertThat(controlTower.listLandingZones(b -> {}).landingZones()).isEmpty();
     }
 }


### PR DESCRIPTION
## Problem

`ControlTowerServiceTest` fails against the current Floci nightly image:

```
ControlTowerServiceTest.shouldListSeededLandingZone:22
Expected size: 1 but was: 0 in: []
ControlTowerServiceTest.shouldGetSeededLandingZone:28 ? IndexOutOfBounds
```

## Root cause

[floci-io/floci#3056](https://github.com/floci-io/floci/pull/3056) (nightly, 2026-09-06) changed the Control Tower default: the emulator no longer seeds a landing zone at startup. `ListLandingZones` now returns an empty list until `CreateLandingZone` is called, unless the new `floci.services.controltower.seed-landing-zone` flag is set (default `false`).

`ControlTowerServiceTest` expected a deterministic seeded landing zone, so it broke.

## Fix

- `ControlTowerServiceTest` now **creates its own landing zone** in `@BeforeAll` (via `CreateLandingZone`) and asserts against it, rather than depending on a seeded fixture.
- Still adds a `seedLandingZone` option to `ControlTowerConfig` (default `false`, mirroring Floci) for callers that want the legacy seeded fixture back; it emits `FLOCI_SERVICES_CONTROLTOWER_SEED_LANDING_ZONE` when the service is enabled. Accessor: `ControlTowerConfig#hasSeedLandingZone()`.
- Updates `ControlTowerConfigTest` and the `FlociContainerServicesConfigTest` wiring test.

## Verification

```
mvn -pl testcontainers-floci test -Dtest=ControlTowerConfigTest,FlociContainerServicesConfigTest,ControlTowerServiceTest
```

all green against a freshly pulled `floci/floci:nightly`. Pre-existing unrelated failures (`FlociContainerTest` DinD, `AthenaServiceTest`, `EksServiceTest`) are untouched.