### PR TITLE
Fix Error Status Code 400 in CloudControlServiceTest.shouldListResources

### DIFF
--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/services/CloudControlServiceTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/services/CloudControlServiceTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.cloudcontrol.CloudControlClient;
 import software.amazon.awssdk.services.cloudcontrol.model.ResourceDescription;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import java.util.List;
 
@@ -11,19 +12,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CloudControlServiceTest extends AbstractServiceTest {
 
+    private static final String BUCKET_NAME = "cloud-control-bucket";
+
     static CloudControlClient cloudControl;
 
     @BeforeAll
     static void setUp() {
         cloudControl = client(CloudControlClient.builder());
+
+        client(S3Client.builder().forcePathStyle(true)).createBucket(b -> b.bucket(BUCKET_NAME));
     }
 
     @Test
     void shouldListResources() {
         List<ResourceDescription> resources = cloudControl
-                .listResources(b -> b.typeName("AWS::SQS::Queue"))
+                .listResources(b -> b.typeName("AWS::S3::Bucket"))
                 .resourceDescriptions();
 
-        assertThat(resources).isNotNull();
+        assertThat(resources).anyMatch(r -> r.identifier().equals(BUCKET_NAME));
     }
 }


### PR DESCRIPTION
# Fix Error Status Code 400 in CloudControlServiceTest.shouldListResources

test: list AWS::S3::Bucket instead of AWS::SQS::Queue in CloudControlServiceTest

---

## Summary

`CloudControlServiceTest.shouldListResources` calls Cloud Control `ListResources` for the resource
type `AWS::SQS::Queue`, which Floci does not support on the read side. The emulator answers with
`UnsupportedActionException` (HTTP 400) instead of an empty result set, so `mvn verify` fails on
`main` with a single error:

```
[ERROR]   CloudControlServiceTest.shouldListResources:24 » UnsupportedAction ListResources is not supported for resource type AWS::SQS::Queue. (Service: CloudControl, Status Code: 400, Request ID: 45cdbcb5-8d52-4208-aa92-a467ff424a07, Extended Request ID: 45cdbcb5-8d52-4208-aa92-a467ff424a07) (SDK Attempt Count: 1)
[ERROR] Tests run: 1179, Failures: 0, Errors: 1, Skipped: 38
```

Per the [Floci Cloud Control documentation](https://floci.io/floci/services/cloudcontrol/), the read
side lists only `AWS::S3::Bucket`, `AWS::EC2::VPC`, `AWS::EC2::Subnet`, `AWS::EC2::SecurityGroup`,
`AWS::EC2::Instance`, `AWS::EC2::LaunchTemplate`, `AWS::IAM::Role`, `AWS::IAM::User` and
`AWS::IAM::InstanceProfile`.

This PR switches the test to `AWS::S3::Bucket`, a type Floci does support for `ListResources`, so the
test exercises the operation as the emulator actually implements it. Test-only change — no production
code is touched.

```diff
--- a/testcontainers-floci/src/test/java/io/floci/testcontainers/services/CloudControlServiceTest.java
+++ b/testcontainers-floci/src/test/java/io/floci/testcontainers/services/CloudControlServiceTest.java
@@ -22,7 +22,7 @@ class CloudControlServiceTest extends AbstractServiceTest {
     @Test
     void shouldListResources() {
         List<ResourceDescription> resources = cloudControl
-                .listResources(b -> b.typeName("AWS::SQS::Queue"))
+                .listResources(b -> b.typeName("AWS::S3::Bucket"))
                 .resourceDescriptions();
 
         assertThat(resources).isNotNull();
     }
```

## Related issue

Fixes #403 

<!-- Se a issue ainda não tiver sido aberta, substitua a linha acima por: -->
<!--
No issue filed. `mvn verify` fails on `main` because the Cloud Control test asserts a resource type
the Floci emulator does not support for `ListResources`, which breaks the build for every contributor.
-->

## Type of change

- [x]  Bug fix (`fix:` commit)
- [ ] New feature (`feat:` commit)
- [ ] Breaking change (`feat!:` commit or `BREAKING CHANGE:` footer)
- [ ] Documentation or chore

<!--
Test-only change, so the commit uses the `test:` type (allowed by @commitlint/config-conventional).
It deliberately does not use `fix:`, which would make release-please cut a patch release even though
no shipped code changed. "Documentation or chore" is the closest box on this list.
-->

## Checklist

- [x] `mvn verify` passes locally (requires Docker)
- [x] New or changed behaviour is covered by tests
- [x] All commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.)
